### PR TITLE
Review round 2

### DIFF
--- a/src/ISafu.sol
+++ b/src/ISafu.sol
@@ -36,5 +36,5 @@ interface ISafu {
         returns (uint256);
 
     // Prevent new deposits. Useful when migrating to a new contract to prevent accidental deposits
-    function shutdown() external;
+    function disableDeposits() external;
 }

--- a/src/ISafu.sol
+++ b/src/ISafu.sol
@@ -7,6 +7,9 @@ interface ISafu {
 
     // Claims all of sender's eligible bounties.
     function claim() external;
+    
+    // Attempts to claim particular receiptId. Returns amount claimed
+    function claim(uint64 id) external returns (uint256);
 
     // Bounty amount and approval status for a given deposit id
     function bounty(uint64 id) external returns (uint256 amt, bool approved);

--- a/src/ISafu.sol
+++ b/src/ISafu.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+interface ISafu {
+    // Record that white-hat has deposited funds.
+    function deposit(address erc20, uint256 wad) external returns (uint64);
+
+    // Claims all of sender's eligible bounties.
+    function claim() external;
+
+    // Bounty amount and approval status for a given deposit id
+    function bounty(uint64 id) external returns (uint256 amt, bool approved);
+
+    // Query bounty cap for token
+    function getBountyCapForToken(address token) external returns (uint256);
+
+    /*****************************/
+    /* Authority only operations */
+    /*****************************/
+
+    // Withdraw deposited funds to authority for given token
+    function withdrawToken(address token) external returns (uint256);
+
+    // Withdraw funds for all tokens
+    function withdraw() external;
+
+    // Approve bounty for deposit id
+    function approveBounty(uint64 id) external;
+
+    // Deny bounty for deposit id
+    function denyBounty(uint64 id) external;
+
+    // Increase the bounty cap for specified token. Bounty caps can only go up
+    function increaseBountyCapForToken(address token, uint256 increase)
+        external
+        returns (uint256);
+
+    // Prevent new deposits. Useful when migrating to a new contract to prevent accidental deposits
+    function shutdown() external;
+}

--- a/src/Safu.sol
+++ b/src/Safu.sol
@@ -173,10 +173,11 @@ contract Safu is ISafu, Ownable {
         ) {
             return 0;
         }
+        require(msg.sender == receipt.depositor, "Safu/only-depositor-can-claim-bounty");
         TokenInfo storage tokenInfo = tokenInfos[receipt.token];
         (uint256 bountyAmt, ) = bounty(receipt);
-        emit Claim(msg.sender, receipt, bountyAmt);
-        IERC20(receipt.token).transfer(msg.sender, bountyAmt);
+        emit Claim(receipt.depositor, receipt, bountyAmt);
+        IERC20(receipt.token).transfer(receipt.depositor, bountyAmt);
         tokenInfo.claimed += bountyAmt;
         // if claimed amount is less than approved bountyAmt,
         // adjust outstanding approvals

--- a/src/Safu.sol
+++ b/src/Safu.sol
@@ -351,7 +351,7 @@ contract Safu is ISafu, Ownable {
     }
 
     modifier notDepositsDisabled() {
-        require(!areDepositsDisabled, "Safu/contract-shudown");
+        require(!areDepositsDisabled, "Safu/deposits-disabled");
         _;
     }
 

--- a/test/Safu.t.sol
+++ b/test/Safu.t.sol
@@ -352,6 +352,38 @@ contract SafuTest is Test {
         assertEq(IERC20(erc20).balanceOf(address(this)), prev + 500);
     }
 
+    function testManyClaims() public {
+        Safu safu = new Safu(
+            defaultMinDelay,
+            defaultMaxDelay,
+            defaultBountyPercent,
+            false
+        );
+        assertTrue(IERC20(erc20).approve(address(safu), 10_000));
+        safu.increaseBountyCapForToken(erc20, defaultBountyCap);
+        uint64 id0 = safu.deposit(erc20, 1_000);
+        uint64 id1 = safu.deposit(erc20, 1_000);
+        uint64 id2 = safu.deposit(erc20, 1_000);
+        uint64 id3 =  safu.deposit(erc20, 1_000);
+        uint64 id4 = safu.deposit(erc20, 1_000);
+
+        safu.approveBounty(id0);
+        safu.approveBounty(id1);
+        safu.approveBounty(id2);
+        safu.approveBounty(id4);
+
+        uint256 prev = IERC20(erc20).balanceOf(address(this));
+        safu.claim();
+        assertEq(IERC20(erc20).balanceOf(address(this)), prev + defaultBountyCap);
+
+        safu.increaseBountyCapForToken(erc20, 500);
+
+        safu.approveBounty(id3);
+        prev = IERC20(erc20).balanceOf(address(this));
+        safu.claim();
+        assertEq(IERC20(erc20).balanceOf(address(this)), prev + 500);
+    }
+
     function testShutdown() public {
         ISafu safu = new Safu(
             defaultMinDelay,
@@ -361,7 +393,7 @@ contract SafuTest is Test {
         );
         safu.increaseBountyCapForToken(erc20, defaultBountyCap);
         assertTrue(IERC20(erc20).approve(address(safu), 10_000));
-        safu.shutdown();
+        safu.disableDeposits();
 
         vm.expectRevert();
         safu.deposit(erc20, 1_000);


### PR DESCRIPTION
- remove rewardsClaimable flag
- require owner withdrawing tokens to wait for minDelay just like depositor
- increment tokenInfo.approved when autoApprove is true
- remove `authority` and use `owner()` instead

Also:
- use storage and memory more directly instead of getters, setters
- when autoApprove is true, add to tokenInfo.approved
- reset closedReceiptsToWithdraw upon withdrawing
- add constructor checks
- rename shutdown -> disableDeposits
- add tests!